### PR TITLE
Base EUR and Symbols CAD

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -184,7 +184,7 @@ function App() {
   useEffect(() => {
     async function fetchRates() {
       setRates(
-        await (await fetch("https://api.exchangeratesapi.io/latest")).json()
+          await (await fetch("https://api.exchangeratesapi.io/latest?base=EUR&symbols=CAD")).json()
       );
     }
     fetchRates();


### PR DESCRIPTION
Use only base EUR and CAD symbols, reduce's  network load and increases speed.  